### PR TITLE
Release 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7555d6c7164cc913be1ce7f95cbecdabda61eb2ccd89008524af306fb7f5031"
+checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
 dependencies = [
  "bitflags",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 libc = "0.2.66"
-nix = "0.22.1"
+nix = "0.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openpty"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Milkey Mouse <milkeymouse@meme.institute>"]
 edition = "2018"
 description = "Rust implementation of libc openpty()"


### PR DESCRIPTION
I raised the minor version instead of only the patch because `nix` updated its minimum supported rust version since the last published openpty version, which used `nix` 0.16.1.
Otherwise, project dependent on openpty would fail to compile with their MSRV.